### PR TITLE
Support latest slack library

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,11 +41,13 @@ func main() {
 }
 
 func runSlackClient(slackApiToken string, stackSite string, tagToChannelName map[string]string, debug bool) {
-	api := slack.New(slackApiToken)
 	logger := log.New(os.Stdout, "slack-bot: ", log.Lshortfile|log.LstdFlags)
-
-	slack.SetLogger(logger)
-	api.SetDebug(debug)
+	
+	api := slack.New(
+		slackApiToken,
+		slack.OptionLog(logger),
+		slack.OptionDebug(debug),
+	)
 
 	rtm := api.NewRTM()
 	go rtm.ManageConnection()


### PR DESCRIPTION
The latest github.com/nlopes/slack library removed SetLogger and SetDebug in favor of this new options syntax.  These were the changes I needed to make it work.